### PR TITLE
Fix crash when changing pages quickly

### DIFF
--- a/src/Internals/SkiaExtensions.cs
+++ b/src/Internals/SkiaExtensions.cs
@@ -32,7 +32,10 @@ internal static class SkiaExtensions
                 ISkiaSharpApiLease lease = leaseFeature.Lease();
                 using (lease)
                 {
-                    lease.SkCanvas.DrawBitmap(bitmap, SKRect.Create((float)Bounds.X, (float)Bounds.Y, (float)Bounds.Width, (float)Bounds.Height));
+                    if (bitmap.Handle != 0)
+                    {
+                        lease.SkCanvas.DrawBitmap(bitmap, SKRect.Create((float)Bounds.X, (float)Bounds.Y, (float)Bounds.Width, (float)Bounds.Height));
+                    }
                 }
             }
         }


### PR DESCRIPTION
I've noticed that an exception occurs when changing pages quickly, both with the button and by typing a value. Checking that the bitmap handle is not 0 seems to fix that.